### PR TITLE
Orgoro memove0bytes mem acces violation

### DIFF
--- a/similarity_search/include/sort_arr_bi.h
+++ b/similarity_search/include/sort_arr_bi.h
@@ -182,7 +182,9 @@ class SortArrBI {
     if (num_elems_ < v_.size()) num_elems_++;
     // curr + 1 <= num_elems_
 
-    memmove(&v_[curr+1], &v_[curr], (num_elems_ - (1 + curr)) * sizeof(v_[0]));
+    if(num_elems_ - (1 + curr) > 0)
+		   memmove(&v_[curr+1], &v_[curr], (num_elems_ - (1 + curr)) * sizeof(v_[0]));
+
 
     v_[curr].used = false;
     v_[curr].key  = key;


### PR DESCRIPTION
while moving 0 bytes is ok

when : curr + 1 == num_elems_

an access violation: &v_[curr+1]

I encountered this error when keys are equal and que is full
