### PR TITLE
Get nmslib and python_vect_bindings to build on mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ CMakeCache.txt
 cmake_install.cmake
 similarity_search/debug
 similarity_search/release
+similarity_search/src/Makefile
 *.o
 

--- a/python_vect_bindings/setup.py
+++ b/python_vect_bindings/setup.py
@@ -1,0 +1,21 @@
+from distutils.core import setup, Extension
+
+libdir='../similarity_search'
+release = '%s/release' % libdir
+
+nmslib_vector = Extension('nmslib_vector', ['nmslib_vector.cc'],
+        include_dirs=['%s/include' % libdir, '%s/release' % libdir],
+        libraries=['gsl', 'gslcblas', 'boost_program_options'],
+        extra_objects=['%s/libNonMetricSpaceLib.a' % release, '%s/liblshkit.a' % release],
+        extra_compile_args=['-std=c++11', '-fno-strict-aliasing'])
+
+
+if __name__ == '__main__':
+    setup(
+            name='nmslib_vector',
+            version='1.5',
+            description='Non-Metric Space Library (NMSLIB)',
+            author='Leonid Boytsov',
+            url='https://github.com/searchivarius/nmslib',
+            long_description='Non-Metric Space Library (NMSLIB) is an efficient cross-platform similarity search library and a toolkit for evaluation of similarity search methods. The goal of the project is to create an effective and comprehensive toolkit for searching in generic non-metric spaces. Being comprehensive is important, because no single method is likely to be sufficient in all cases. Also note that exact solutions are hardly efficient in high dimensions and/or non-metric spaces. Hence, the main focus is on approximate methods.',
+            ext_modules=[nmslib_vector])

--- a/similarity_search/include/simd.h
+++ b/similarity_search/include/simd.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#if (defined(__x86_64__) || defined(__i386__))
+     /* GCC-compatible compiler, targeting x86/x86-64 */
+     #include <x86intrin.h>
+#elif defined(__ARM_NEON__)
+     /* GCC-compatible compiler, targeting ARM with NEON */
+     #include <arm_neon.h>
+#elif defined(__IWMMXT__)
+     /* GCC-compatible compiler, targeting ARM with WMMX */
+     #include <mmintrin.h>
+#elif (defined(__VEC__) || defined(__ALTIVEC__))
+     /* XLC or GCC-compatible compiler, targeting PowerPC with VMX/VSX */
+     #include <altivec.h>
+#elif defined(__SPE__)
+     /* GCC-compatible compiler, targeting PowerPC with SPE */
+     #include <spe.h>
+#endif

--- a/similarity_search/include/sort_arr_bi.h
+++ b/similarity_search/include/sort_arr_bi.h
@@ -22,6 +22,7 @@
 #include <stdexcept>
 #include <vector>
 #include <algorithm>
+#include "simd.h"
 
 /*
  * This is not a fully functional heap and this is done on purpose.

--- a/similarity_search/src/method/hnsw.cc
+++ b/similarity_search/src/method/hnsw.cc
@@ -30,6 +30,7 @@
 #include <iostream>
 #include <mmintrin.h>
 
+#include "simd.h"
 #include "space.h"
 #include "knnquery.h"
 #include "rangequery.h"

--- a/similarity_search/src/method/hnsw_distfunc_opt.cc
+++ b/similarity_search/src/method/hnsw_distfunc_opt.cc
@@ -24,6 +24,7 @@
 *
 *
 */
+#include "simd.h"
 #include "space.h"
 #include "knnquery.h"
 #include "rangequery.h"


### PR DESCRIPTION
These are the changes I had to make to get nmslib to build on os x with anaconda. They are:

1. explicitly including `x86intrin.h` or equivalent for your CPU architecture
2. adding a setup.py script for python_vect_bindings so that it uses the correct include paths