### PR TITLE
add WITHOUT_TESTS, fix IdType bugs

### DIFF
--- a/similarity_search/CMakeLists.txt
+++ b/similarity_search/CMakeLists.txt
@@ -132,6 +132,8 @@ if (WITH_EXTRAS)
 endif()
 
 add_subdirectory (src)
-add_subdirectory (test)
+if (NOT WITHOUT_TESTS)
+    add_subdirectory (test)
+endif()
 
 message (STATUS "Compiler: ${CMAKE_CXX_COMPILER_ID} ${CXX_COMPILER_VERSION}")

--- a/similarity_search/include/experimentconf.h
+++ b/similarity_search/include/experimentconf.h
@@ -41,8 +41,8 @@ public:
                    const string& datafile,
                    const string& queryfile,
                    unsigned TestSetQty, // The # of times the datafile is randomly divided into the query and the test set
-                   IdTypeUnsign MaxNumData,
-                   IdTypeUnsign MaxNumQueryToRun,
+                   unsigned MaxNumData,
+                   unsigned MaxNumQueryToRun,
                    const typename std::vector<unsigned>& knn,
                    float eps,
                    const typename std::vector<dist_t>& range)

--- a/similarity_search/include/space/space_sparse_vector.h
+++ b/similarity_search/include/space/space_sparse_vector.h
@@ -109,7 +109,7 @@ public:
   virtual size_t GetElemQty(const Object* object) const {return 0;}
 
 protected:
-  void ReadSparseVec(std::string line, size_t line_num, IdType& label, vector<ElemType>& v) const;
+  void ReadSparseVec(std::string line, size_t line_num, LabelType& label, vector<ElemType>& v) const;
   virtual void CreateVectFromObj(const Object* obj, vector<ElemType>& v) const  = 0;
   DISABLE_COPY_AND_ASSIGN(SpaceSparseVector);
 };

--- a/similarity_search/src/main.cc
+++ b/similarity_search/src/main.cc
@@ -143,8 +143,8 @@ void RunExper(bool                                bPrintProgress,
              const string&                        CacheGSFilePrefix,
              float                                maxCacheGSRelativeQty,
              bool                                 recallOnly,
-             IdTypeUnsign                         MaxNumData,
-             IdTypeUnsign                         MaxNumQuery,
+             unsigned                             MaxNumData,
+             unsigned                             MaxNumQuery,
              const                                vector<unsigned>& knn,
              const                                float eps,
              const string&                        RangeArg
@@ -519,8 +519,8 @@ int main(int ac, char* av[]) {
   string                CacheGSFilePrefix;
   float                 maxCacheGSRelativeQty;
   bool                  recallOnly;
-  IdTypeUnsign          MaxNumData;
-  IdTypeUnsign          MaxNumQuery;
+  unsigned              MaxNumData;
+  unsigned              MaxNumQuery;
   vector<unsigned>      knn;
   string                RangeArg;
   float                 eps = 0.0;

--- a/similarity_search/src/space.cc
+++ b/similarity_search/src/space.cc
@@ -29,7 +29,7 @@ unique_ptr<DataFileInputState> Space<dist_t>::ReadDataset(ObjectVector& dataset,
   CHECK_MSG(MaxNumObjects >=0, "Bug: MaxNumObjects should be >= 0");
   unique_ptr<DataFileInputState> inpState(OpenReadFileHeader(inputFile));
   string line;
-  IdType label;
+  LabelType label;
   string externId;
   for (size_t id = 0; id < MaxNumObjects || !MaxNumObjects; ++id) {
     if (!ReadNextObjStr(*inpState, line, label, externId)) break;

--- a/similarity_search/src/tune_vptree.cc
+++ b/similarity_search/src/tune_vptree.cc
@@ -70,8 +70,8 @@ void RunExper(unsigned AddRestartQty,
              unsigned                       TestSetQty,
              const string&                  DataFile,
              const string&                  QueryFile,
-             IdTypeUnsign                   MaxNumData,
-             IdTypeUnsign                   MaxNumQuery,
+             unsigned                       MaxNumData,
+             unsigned                       MaxNumQuery,
              vector<unsigned>               knnAll,
              float                          eps,
              const string&                  RangeArg,
@@ -431,8 +431,8 @@ int main(int ac, char* av[]) {
   string                  DataFile;
   string                  QueryFile;
   float                   MaxCacheGSRelativeQty;
-  IdTypeUnsign            MaxNumData;
-  IdTypeUnsign            MaxNumQuery;
+  unsigned                MaxNumData;
+  unsigned                MaxNumQuery;
   vector<unsigned>        knn;
   string                  RangeArg;
   float                   eps;

--- a/similarity_search/test/test_clust.cc
+++ b/similarity_search/test/test_clust.cc
@@ -91,7 +91,7 @@ void RunExper(
     const string&          SpaceType,
     shared_ptr<AnyParams>  SpaceParams,
     const string&          DataFile,
-    IdTypeUnsign           MaxNumData,
+    unsigned               MaxNumData,
     const string&          ClustType,
     IdTypeUnsign           ClustQty,
     // reductive CLARANS parameters
@@ -254,7 +254,7 @@ int main(int argc, char* argv[]) {
   string                  ClustType;
   IdTypeUnsign            ClustQty;
   string                  DataFile;
-  IdTypeUnsign            MaxNumData;
+  unsigned                MaxNumData;
 
 // reductive CLARANS parameters
   IdTypeUnsign            maxMetaIterQty;

--- a/similarity_search/test/test_integr_util.h
+++ b/similarity_search/test/test_integr_util.h
@@ -219,8 +219,8 @@ string CreateCmdStr(
              unsigned                     TestSetQty,
              const string&                DataFile,
              const string&                QueryFile,
-             IdTypeUnsign                 MaxNumData,
-             IdTypeUnsign                 MaxNumQuery,
+             unsigned                     MaxNumData,
+             unsigned                     MaxNumQuery,
              const                        float eps) {
   stringstream res;
   // our test data files shouldn't have spaces, so we won't escape them
@@ -257,8 +257,8 @@ size_t RunTestExper(const vector<MethodTestCase>& vTestCases,
              unsigned                     TestSetQty,
              const string&                DataFile,
              const string&                QueryFile,
-             IdTypeUnsign                 MaxNumData,
-             IdTypeUnsign                 MaxNumQuery,
+             unsigned                     MaxNumData,
+             unsigned                     MaxNumQuery,
              const string&                KnnArg,
              const                        float eps,
              const string&                RangeArg
@@ -513,8 +513,8 @@ inline bool RunOneTest(const vector<MethodTestCase>& vTestCases,
                unsigned                     TestSetQty,
                const string&                DataFile,
                const string&                QueryFile,
-               IdTypeUnsign                 MaxNumData,
-               IdTypeUnsign                 MaxNumQuery,
+               unsigned                     MaxNumData,
+               unsigned                     MaxNumQuery,
                const string&                KnnArg,
                const                        float eps,
                const string&                RangeArg) {


### PR DESCRIPTION
1. Allow to build without tests via WITHOUT_TESTS cmake
2. Fix bugs in types. Before this commit it was impossible to compile project without fatal errors if you change IdType typedef in IdType.h file