### PR TITLE
Assorted minor fixes.

### DIFF
--- a/python_bindings/nmslib.cc
+++ b/python_bindings/nmslib.cc
@@ -88,6 +88,10 @@ struct IndexWrapper {
     auto factory = MethodFactoryRegistry<dist_t>::Instance();
     index.reset(factory.CreateMethod(print_progress, method, space_type, *space, data));
     index->LoadIndex(filename);
+
+    // querying reloaded indices don't seem to work correctly (at least hnsw ones) until
+    // SetQueryTimeParams is called
+    index->ResetQueryTimeParams();
   }
 
   void saveIndex(const std::string & filename) {

--- a/python_bindings/setup.py
+++ b/python_bindings/setup.py
@@ -79,18 +79,19 @@ class BuildExt(build_ext):
     """A custom build extension for adding compiler-specific options."""
     c_opts = {
         'msvc': ['/EHsc', '/openmp', '/O2'],
-        'unix': ['-O3'],
+        'unix': ['-O3', '-msse4.2'],
     }
     link_opts = {
-        'unix': ['-pthread'],
+        'unix': [],
         'msvc': [],
     }
 
     if sys.platform == 'darwin':
         c_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']
+        link_opts['unix'] += ['-stdlib=libc++', '-mmacosx-version-min=10.7']
     else:
         c_opts['unix'].append("-fopenmp")
-        link_opts['unix'].append('-fopenmp')
+        link_opts['unix'].extend(['-fopenmp', '-pthread'])
 
     def build_extensions(self):
         ct = self.compiler.compiler_type

--- a/similarity_search/include/memory.h
+++ b/similarity_search/include/memory.h
@@ -28,7 +28,9 @@ class MemUsage {
   double get_vmsize();
 
  private:
+#ifdef __linux
   char status_file_[50];
+#endif
 };
 
 }   // namespace similarity

--- a/similarity_search/include/method/hnsw.h
+++ b/similarity_search/include/method/hnsw.h
@@ -568,7 +568,7 @@ namespace similarity {
                 curV++;
             }
         };
-        ~VisitedList() { delete mass; }
+        ~VisitedList() { delete [] mass; }
     };
     ///////////////////////////////////////////////////////////
     //
@@ -579,7 +579,6 @@ namespace similarity {
     class VisitedListPool {
         deque<VisitedList *> pool;
         mutex poolguard;
-        int maxpools;
         int numelements;
 
     public:

--- a/similarity_search/include/method/small_world_rand.h
+++ b/similarity_search/include/method/small_world_rand.h
@@ -253,7 +253,7 @@ public:
                  const Space<dist_t>& space,
                  const ObjectVector& data);
   void CreateIndex(const AnyParams& IndexParams) override;
-  virtual void AddBatch(const ObjectVector& batchData, bool bPrintProgress, bool bCheckIDs = false);
+  virtual void AddBatch(const ObjectVector& batchData, bool bPrintProgress, bool bCheckIDs = false) override;
   virtual void DeleteBatch(const ObjectVector& batchData, int delStrategy,
                            bool checkIDs = false/* this is a debug flag only, turning it on may affect performance */) override;
 

--- a/similarity_search/include/space/space_ab_diverg.h
+++ b/similarity_search/include/space/space_ab_diverg.h
@@ -50,7 +50,7 @@ class SpaceAlphaBetaDiverg : public VectorSpaceSimpleStorage<dist_t> {
   explicit SpaceAlphaBetaDiverg(float alpha, float beta) : alpha_(alpha), beta_(beta) {}
   virtual ~SpaceAlphaBetaDiverg() {}
 
-  virtual std::string StrDesc() const;
+  virtual std::string StrDesc() const override;
  protected:
   virtual dist_t HiddenDistance(const Object* obj1, const Object* obj2) const override;
   virtual dist_t ProxyDistance(const Object* obj1, const Object* obj2) const override;

--- a/similarity_search/include/space/space_sparse_vector.h
+++ b/similarity_search/include/space/space_sparse_vector.h
@@ -123,7 +123,7 @@ public:
   explicit SpaceSparseVectorSimpleStorage() {}
 
   virtual void CreateDenseVectFromObj(const Object* obj, dist_t* pVect,
-                                 size_t nElem) const {
+                                 size_t nElem) const override {
     static std::hash<size_t>   indexHash;
     fill(pVect, pVect + nElem, static_cast<dist_t>(0));
     const ElemType* beg = reinterpret_cast<const ElemType*>(obj->data());
@@ -142,7 +142,7 @@ public:
 protected:
   DISABLE_COPY_AND_ASSIGN(SpaceSparseVectorSimpleStorage);
 
-  virtual void CreateVectFromObj(const Object* obj, vector<ElemType>& v) const {
+  virtual void CreateVectFromObj(const Object* obj, vector<ElemType>& v) const override {
     const ElemType* beg = reinterpret_cast<const ElemType*>(obj->data());
     const ElemType* const end =
         reinterpret_cast<const ElemType*>(obj->data() + obj->datalength());
@@ -150,8 +150,6 @@ protected:
     v.resize(qty);
     for (size_t i = 0; i < qty; ++i) v[i] = beg[i];
   }
-
-  virtual dist_t HiddenDistance(const Object* obj1, const Object* obj2) const = 0;
 
   /* 
    * This helper function converts a dense vector to a sparse one and then calls a generic distance function.

--- a/similarity_search/src/distcomp_sparse_scalar_fast.cc
+++ b/similarity_search/src/distcomp_sparse_scalar_fast.cc
@@ -157,10 +157,10 @@ ScalarProductFastRes SparseScalarProductFastIntern(const char* pData1, size_t le
       float *pVal2 = val2;
 
       size_t i1 = 0, i2 = 0;
-      size_t iEnd1 = qty1 / 8 * 8;
-      size_t iEnd2 = qty2 / 8 * 8;
 
 #ifdef PORTABLE_SSE4
+      size_t iEnd1 = qty1 / 8 * 8;
+      size_t iEnd2 = qty2 / 8 * 8;
       if (i1 < iEnd1 && i2 < iEnd2) {
         while (pBlockIds1[i1 + 7] < pBlockIds2[i2]) {
           i1 += 8;

--- a/similarity_search/src/method/hnsw.cc
+++ b/similarity_search/src/method/hnsw.cc
@@ -160,6 +160,8 @@ namespace similarity {
 
 #ifdef _OPENMP
         indexThreadQty_ = omp_get_max_threads();
+#else
+        indexThreadQty_ = 1;
 #endif
         pmgr.GetParamOptional("indexThreadQty", indexThreadQty_, indexThreadQty_);
         // indexThreadQty_ = 1;


### PR DESCRIPTION
1) Fixed some errors found by valgrind

indexThreadQty in hnsw.cc wasn't initialized on osx, causing some chaos. Default to 1 without
openmp
```
==78687== Conditional jump or move depends on uninitialised value(s)
==78687==    at 0x101B2D419: similarity::VisitedListPool::VisitedListPool(int, int) (hnsw.h:588)
```

Also fixed this:
```
==44990== Mismatched free() / delete / delete []
==44990==    at 0x4C2C2BC: operator delete(void*) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==44990==    by 0x4763B8: ~VisitedList (hnsw.h:571)
```

2) Fixed various compiler warnings (mainly on osx)

```
./nmslib/similarity_search/include/method/hnsw.h:582:13: warning: private field 'maxpools' is not used [-Wunused-private-field]
./nmslib/similarity_search/include/memory.h:31:8: warning: private field 'status_file_' is not used [-Wunused-private-field]
./nmslib/similarity_search/include/method/small_world_rand.h:256:16: warning: 'AddBatch' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
./nmslib/similarity_search/include/space/space_ab_diverg.h:53:23: warning: 'StrDesc' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
./nmslib/similarity_search/include/space/space_sparse_vector.h:125:16: warning: 'CreateDenseVectFromObj' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
./nmslib/similarity_search/include/space/space_sparse_vector.h:145:16: warning: 'CreateVectFromObj' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
./nmslib/similarity_search/include/space/space_sparse_vector.h:154:18: warning: 'HiddenDistance' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
nmslib/similarity_search/src/distcomp_sparse_scalar_fast.cc:233:9: warning: nmslib/similarity_search/src/distcomp_sparse_scalar_fast.cc(233) : WARNING: No SSE 4.2, defaulting to scalar implementation! [-W#pragma-messages]
nmslib/similarity_search/src/distcomp_sparse_scalar_fast.cc:160:14: warning: unused variable 'iEnd1' [-Wunused-variable]
nmslib/similarity_search/src/distcomp_sparse_scalar_fast.cc:161:14: warning: unused variable 'iEnd2' [-Wunused-variable]
clang: warning: argument unused during compilation: '-pthread'
ld: warning: object file (build/temp.macosx-10.6-x86_64-2.7/nmslib.o) was built for newer OSX version (10.7) than being linked (10.6)
```

3)  Finally saveIndex/loadIndex wasn't working properly in python.

Fixed and added unittests for this.