### PR TITLE
fail travis build on error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
 
 script:
 - |
+  set -e
   if [ "$TRAVIS_OS_NAME" = "linux" -o "$TRAVIS_OS_NAME" = "osx" ] ; then
       cd similarity_search;
       ./release/bunit


### PR DESCRIPTION
With this change, the travis build fails on OSX when bunit fails:
https://travis-ci.org/benfred/nmslib/builds/238841730