### PR TITLE
Fix memory leaks in HNSW

### DIFF
--- a/similarity_search/include/method/hnsw.h
+++ b/similarity_search/include/method/hnsw.h
@@ -504,7 +504,7 @@ namespace similarity {
 
         //
     private:
-        std::default_random_engine *generator;
+        std::unique_ptr<std::default_random_engine> generator;
         size_t M_;
         size_t maxM_;
         size_t maxM0_;

--- a/similarity_search/src/method/hnsw.cc
+++ b/similarity_search/src/method/hnsw.cc
@@ -464,7 +464,7 @@ namespace similarity {
         if (data_level0_memory_)
             free(data_level0_memory_);
         if (linkLists_) {
-            for (int i = 0; i < ElList_.size(); i++) {
+            for (int i = 0; i < data_rearranged_.size(); i++) {
                 if (linkLists_[i])
                     free(linkLists_[i]);
             }

--- a/similarity_search/src/method/hnsw.cc
+++ b/similarity_search/src/method/hnsw.cc
@@ -149,7 +149,7 @@ namespace similarity {
     {
         AnyParamManager pmgr(IndexParams);
 
-        generator = new std::default_random_engine(100);
+        generator.reset(new std::default_random_engine(100));
 
         pmgr.GetParamOptional("M", M_, 16);
 

--- a/similarity_search/src/method/hnsw.cc
+++ b/similarity_search/src/method/hnsw.cc
@@ -421,7 +421,7 @@ namespace similarity {
         AnyParamManager pmgr(QueryTimeParams);
 
         if (pmgr.hasParam("ef") && pmgr.hasParam("efSearch")) {
-            throw new runtime_error("The user shouldn't specify parameters ef and efSearch at the same time (they are synonyms)");
+            throw runtime_error("The user shouldn't specify parameters ef and efSearch at the same time (they are synonyms)");
         }
 
         // ef and efSearch are going to be parameter-synonyms with the default value 20


### PR DESCRIPTION
Here are several fixes in the HNSW index. Each fix is in its own commit.
The most significant one is the leak of link lists. It can leak a lot if indexes are loaded and destroyed multiple times during a program lifetime.