### PR TITLE
Minor doc fixes

### DIFF
--- a/python_bindings/docs/api.rst
+++ b/python_bindings/docs/api.rst
@@ -9,6 +9,19 @@ function should be called first before calling any other method.
 
 .. autofunction:: nmslib.init
 
+
+.. class:: nmslib.DistType
+
+    .. attribute:: FLOAT
+    .. attribute:: DOUBLE
+    .. attribute:: INT
+
+.. class:: nmslib.DataType
+
+    .. attribute:: DENSE_VECTOR
+    .. attribute:: OBJECT_AS_STRING
+    .. attribute:: SPARSE_VECTOR
+
 nmslib.FloatIndex
 -----------------
 

--- a/python_bindings/nmslib.cc
+++ b/python_bindings/nmslib.cc
@@ -438,7 +438,7 @@ void exportIndex(py::module * m) {
     .def("knnQueryBatch", &IndexWrapper<dist_t>::knnQueryBatch,
       py::arg("queries"), py::arg("k") = 10, py::arg("num_threads") = 0,
       "Performs multiple queries on the index, distributing the work over \n"
-      "a thread pool\n"
+      "a thread pool\n\n"
       "Parameters\n"
       "----------\n"
       "input: list\n"


### PR DESCRIPTION
The formatting for knnQueryBatch is messed up because of a missing
newline: https://searchivarius.github.io/nmslib/api.html#nmslib.dist.FloatIndex.knnQueryBatch . Also listed out values for the DistType/DataType enums