### PR TITLE
Fix docstrings for addDataPoint/addDataPointBatch

### DIFF
--- a/python_bindings/nmslib.cc
+++ b/python_bindings/nmslib.cc
@@ -485,7 +485,7 @@ void exportIndex(py::module * m) {
     .def("addDataPoint", &IndexWrapper<dist_t>::addDataPoint,
       py::arg("id"),
       py::arg("data"),
-      "Saves the index to disk\n\n"
+      "Adds a single data point to the index\n\n"
       "Parameters\n"
       "----------\n"
       "id: int\n"
@@ -500,7 +500,7 @@ void exportIndex(py::module * m) {
     .def("addDataPointBatch", &IndexWrapper<dist_t>::addDataPointBatch,
       py::arg("data"),
       py::arg("ids") = py::none(),
-      "Saves the index to disk\n\n"
+      "Adds several data points to the index\n\n"
       "Parameters\n"
       "----------\n"
       "data: object\n"

--- a/python_bindings/tests/bindings_test.py
+++ b/python_bindings/tests/bindings_test.py
@@ -53,7 +53,6 @@ class DenseIndexTestMixin(object):
         for query, (ids, distances) in zip(queries, results):
             self.assertTrue(get_hitrate(get_exact_cosine(query, data), ids) >= 5)
 
-
     def testReloadIndex(self):
         np.random.seed(23)
         data = np.random.randn(1000, 10).astype(np.float32)


### PR DESCRIPTION
Docstrings for addDataPoint/addDataPointBatch were cut and
paste incorrectly. Fix.

Also fix flake8 warning that is in the master branch, and is causing
this build to be marked as failing: https://github.com/searchivarius/nmslib/pull/234