### PR TITLE
Fix rvm issue on travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,10 @@ before_install:
 - |
   if [ "$TRAVIS_OS_NAME" = "linux" ]; then export CXX=g++-4.8 CC=gcc-4.8; fi
   if [ "$TRAVIS_OS_NAME" = "osx" ] && [ "${PYTHON:0:1}" = "3" ]; then
-      brew update; brew install python3; rvm get head || true 
+      brew update
+      brew install python3
+      command curl -sSL https://rvm.io/mpapis.asc | gpg --import -;
+      rvm get stable
   fi
   pip install --user --upgrade pip virtualenv
   virtualenv -p python$PYTHON venv


### PR DESCRIPTION
We were seeing an error on OSX build in travis, complaining about shell_session_update not being
found. This seems to be the same issue as here https://github.com/travis-ci/travis-ci/issues/6307
Fix by getting latest stable rvm.