### PR TITLE
Improved knnQueryBatch performance

### DIFF
--- a/similarity_search/include/thread_pool.h
+++ b/similarity_search/include/thread_pool.h
@@ -65,45 +65,53 @@ namespace similarity {
       numThreads = std::thread::hardware_concurrency();
     }
 
-    std::vector<std::thread>  threads;
-    std::atomic<size_t>       current(start);
+    if (numThreads == 1) {
+      for (size_t id = start; id < end; id++) {
+        fn(id);
+      }
+    } else {
+      std::vector<std::thread>  threads;
+      std::atomic<size_t>       current(start);
 
-    // keep track of exceptions in threads
-    // https://stackoverflow.com/a/32428427/1713196
-    std::exception_ptr lastException = nullptr;
-    std::mutex         lastExceptMutex;
+      // keep track of exceptions in threads
+      // https://stackoverflow.com/a/32428427/1713196
+      std::exception_ptr lastException = nullptr;
+      std::mutex         lastExceptMutex;
 
-    for (size_t i = 0; i < numThreads; ++i) {
-      threads.push_back(std::thread([&] {
-        while (true) {
-          size_t id = current.fetch_add(1);
+      for (size_t i = 0; i < numThreads; ++i) {
+        threads.push_back(std::thread([&] {
+          while (true) {
+            size_t id = current.fetch_add(1);
 
-          if ((id >= end)) {
-            break;
+            if ((id >= end)) {
+              break;
+            }
+
+            try {
+              fn(id);
+            } catch (...) {
+              std::unique_lock<std::mutex> lastExcepLock(lastExceptMutex);
+              lastException = std::current_exception();
+              /* 
+               * This will work even when current is the largest value that
+               * size_t can fit, because fetch_add returns the previous value
+               * before the increment (what will result in overflow 
+               * and produce 0 instead of current + 1).
+               */
+              current = end;
+              break;
+            }
           }
+        }));
+      }
+      for (auto & thread : threads) {
+        thread.join();
+      }
+      if (lastException) {
+        std::rethrow_exception(lastException);
+      }
+    }
 
-          try {
-            fn(id);
-          } catch (...) {
-            std::unique_lock<std::mutex> lastExcepLock(lastExceptMutex);
-            lastException = std::current_exception();
-            /* 
-             * This will work even when current is the largest value that
-             * size_t can fit, because fetch_add returns the previous value
-             * before the increment (what will result in overflow 
-             * and produce 0 instead of current + 1).
-             */
-            current = end;
-            break;
-          }
-        }
-      }));
-    }
-    for (auto & thread : threads) {
-      thread.join();
-    }
-    if (lastException) {
-      std::rethrow_exception(lastException);
-    }
+
   }
 };


### PR DESCRIPTION
The changes are twofold:

1. Improved single-threaded batch-performance. The original method did not condition on single-threaded situations, introducing approximately 20ms overhead in thread initialisation.
2. Converted knnQueryBatch to use a tuple of NumPy arrays instead of a list of NumPy arrays. This makes intuitive sense as vector operations over the arrays are faster than working on lists and splitting the tuples, and then reconstructing NumPy arrays from them.