### PR TITLE
Fix addDataPointBatch where ids != None

### DIFF
--- a/python_bindings/nmslib.cc
+++ b/python_bindings/nmslib.cc
@@ -193,7 +193,7 @@ struct IndexWrapper {
   size_t readObjectVector(py::object input, ObjectVector * output,
                           py::object ids_ = py::none()) {
     std::vector<int> ids;
-    if (!ids_) {
+    if (!ids_.is_none()) {
       ids = py::cast<std::vector<int>>(ids_);
     }
 

--- a/python_bindings/tests/bindings_test.py
+++ b/python_bindings/tests/bindings_test.py
@@ -53,6 +53,18 @@ class DenseIndexTestMixin(object):
         for query, (ids, distances) in zip(queries, results):
             self.assertTrue(get_hitrate(get_exact_cosine(query, data), ids) >= 5)
 
+        # test custom ids (set id to square of each row)
+        index = self._get_index()
+        index.addDataPointBatch(data, ids=np.arange(data.shape[0]) ** 2)
+        index.createIndex()
+
+        queries = data[:10]
+        results = index.knnQueryBatch(queries, k=10)
+        for query, (ids, distances) in zip(queries, results):
+            # convert from square back to row id
+            ids = np.sqrt(ids).astype(int)
+            self.assertTrue(get_hitrate(get_exact_cosine(query, data), ids) >= 5)
+
     def testReloadIndex(self):
         np.random.seed(23)
         data = np.random.randn(1000, 10).astype(np.float32)


### PR DESCRIPTION
I introduced a bug in my previous commit, and passing ids to addDataPointBatch
wasn't being respected. Fix this, and add a unittest so that this will be caught
int the future.