### PR TITLE
Fix deadlock in child threads launched from python

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Non-Metric Space Library (NMSLIB) 
 =================
-The latest **pre**-release is [1.7](https://github.com/searchivarius/nmslib/releases/tag/v1.7). Note that the manual is not updated to reflect some of the changes. In particular, we changed the build procedure for Windows. Also note that the manual targets primiarily developers who will extend the library. For most other folks, [Python binding docs should be sufficient](python_bindings).
+The latest **pre**-release is [1.7.1](https://github.com/searchivarius/nmslib/releases/tag/v1.7.1). Note that the manual is not updated to reflect some of the changes. In particular, we changed the build procedure for Windows. Also note that the manual targets primiarily developers who will extend the library. For most other folks, [Python binding docs should be sufficient](python_bindings).
 -----------------
 Non-Metric Space Library (NMSLIB) is an **efficient** cross-platform similarity search library and a toolkit for evaluation of similarity search methods. The core-library does **not** have any third-party dependencies.
 


### PR DESCRIPTION
Pybind11 seems to have an issue in gil_scoped_acquire when being
called from child threads created from python. This resulted in a deadlock here:
https://github.com/searchivarius/nmslib/issues/291

A simple workaround is to use the PyGILState_Ensure from the python c-api directly
instead.